### PR TITLE
Change request method to post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2.0.0]
+    - change method to POST
+
 ## [1.1.2]
     - update readme.md
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Kindly append `delivery_url` parameter to firebase `data`
 ```json
 {
 	"data" : {
-    	"delivery_url": "http://localhost/set-read/886d27ee-f6fd-11e9-832d-362b9e155667"
+        "delivery_url": "http://localhost/set-read/886d27ee-f6fd-11e9-832d-362b9e155667"
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Kindly append `delivery_url` parameter to firebase `data`
 }
 ```
 
-After push received and processed by `phonegap-plugin-push` in foreground/background, plugin will make GET request to `http://localhost/set-read/886d27ee-f6fd-11e9-832d-362b9e155667` automatically.
+After push received and processed by `phonegap-plugin-push` in foreground/background, plugin will make **POST** request to `http://localhost/set-read/886d27ee-f6fd-11e9-832d-362b9e155667` automatically.
 So, it doesn't need to write any Javascript code.
 
 It is possible to detect if plugin is installed. No available methods in the `CordovaPushDelivery` object right now.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #### Description
 
 A plugin that overrides the ```onMessageReceived()``` method of the `phonegap-plugin-push` package.
-It introduces a possibility to detect if push is received in foreground / background and sends a fallback GET request.
+It introduces a possibility to detect if push is received in foreground / background and sends a fallback **POST** request.
 
 **Only Android support right now.**
 #### How to install
@@ -22,7 +22,7 @@ Kindly append `delivery_url` parameter to firebase `data`
 }
 ```
 
-After push received and processed by `phonegap-plugin-push` in foreground/background, plugin will make **POST** request to `http://localhost/set-read/886d27ee-f6fd-11e9-832d-362b9e155667` automatically.
+After push received and processed by `phonegap-plugin-push` in foreground/background, plugin will make **POST*** request to `http://localhost/set-read/886d27ee-f6fd-11e9-832d-362b9e155667` automatically.
 So, it doesn't need to write any Javascript code.
 
 It is possible to detect if plugin is installed. No available methods in the `CordovaPushDelivery` object right now.

--- a/src/android/com/android/plugins/DeliveryService.java
+++ b/src/android/com/android/plugins/DeliveryService.java
@@ -31,6 +31,7 @@ public class DeliveryService extends FCMService {
       try {
         URL url = new URL(message.getData().get(key));
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
+        urlConnection.setRequestMethod("POST");
         out = new BufferedOutputStream(urlConnection.getOutputStream());
 
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out, "UTF-8"));


### PR DESCRIPTION
Changes the `get `method to `post` as it is more architecturally correct